### PR TITLE
Fix "window is not defined" error during build

### DIFF
--- a/src/components/button-scroll-top.js
+++ b/src/components/button-scroll-top.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import styled from "styled-components"
 
-import Button from "./Button"
+import Button from "./button"
 
 const StyledFab = styled(Button)`
   position: fixed;
@@ -47,7 +47,9 @@ export default function Fab({ children, ...props }) {
     window.scrollTo({ top: 0, behavior: "smooth" })
   }
 
-  window.addEventListener("scroll", checkScrollTop)
+  if (typeof window !== "undefined") {
+    window.addEventListener("scroll", checkScrollTop)
+  }
 
   return (
     <StyledFab


### PR DESCRIPTION
## What issue did you solve?

- Fix "window is not defined" error during build

![Screenshot 2020-10-29 at 17 58 05](https://user-images.githubusercontent.com/18502234/97560096-d7f6b280-1a10-11eb-8352-5fce8371204f.png)

## How did you solve the issue?

Check `window` object is exist first before using it
