### PR TITLE
fix incorrect posts order on homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -73,7 +73,7 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { order: DESC, fields: [frontmatter___date] }
+      sort: { order: DESC, fields: [fields___date] }
       filter: { frontmatter: { category: { eq: "blog" } } }
     ) {
       nodes {


### PR DESCRIPTION
## What issue did you solve?

Closes #27 

## How did you solve the issue?

Our posts are ordered using unknown field

```
...
sort: { order: DESC, fields: [frontmatter___date] }
...
```

`frontmatter___date` doesn't exist, So, I changed the code using the valid field, which is `fields___date`