### PR TITLE
fix: redirection issue on Netlify

### DIFF
--- a/.changeset/twenty-apricots-notice.md
+++ b/.changeset/twenty-apricots-notice.md
@@ -1,0 +1,5 @@
+---
+"trihargianto-com": patch
+---
+
+Fix redirection issue on Netlify.

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,10 @@
+# NETLIFY REDIRECT CONFIGURATIONS
+# Ref: https://docs.netlify.com/routing/redirects/redirect-options/
+# ---
+# Handle redirection for old pages from old site (GatsbyJS ver).
+# The old site support i18n, but the new site doesn't.
+# I decided to remove i18n support on the new site because it's too much work to maintain.
+# Thus, we need to redirect old i18n pages to the new ones.
+
+/id/* /blog/:splat 301
+/en/* /blog/:splat 301

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,22 +18,5 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
-  /**
-   * Handle redirection for old pages from old site (GatsbyJS ver).
-   * The old site support i18n, but the new site doesn't.
-   * I decided to remove i18n support on the new site because it's too much work to maintain.
-   * Thus, we need to redirect old i18n pages to the new ones.
-   */
-  redirects: {
-    "/en/[...slug]": {
-      status: 301,
-      destination: "/blog/[...slug]",
-    },
-    "/id/[...slug]": {
-      status: 301,
-      destination: "/blog/[...slug]",
-    },
-  },
-
   adapter: netlify(),
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.0",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && cp _redirects dist/_redirects",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
[The Redirect](https://docs.astro.build/en/guides/routing/#redirects) feature from Astro seems not working when hosted on Netlify. 

Add additional command to the `build` script based on [Cassidy Williams post](https://cassidoo.co/post/netlify-redirects-astro/)